### PR TITLE
Fix x509: failed to load system roots and no roots provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN curl https://glide.sh/get | sh \
 RUN cd /go/src/github.com/anchorfree/jira-alerter && env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -ldflags "-X main.Version=0.5" -o /build/jira-alerter github.com/anchorfree/jira-alerter/cmd/jiralert/
 
 FROM alpine
-
+RUN apk add ca-certificates
 COPY --from=0 /build/jira-alerter /
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
I received

> ERROR: No response returned: Get https://xxx.atlassian.net/rest/api/2/search?jql=project%3DAM+order+by+key&startAt=0&maxResults=50&expand=&fields=summary,status,resolution&validateQuery=: x509: failed to load system roots and no roots provided

error and fixed in the Dockerfile with 'apk add ca-certificates'